### PR TITLE
Fix install.sh error when no .env file is present

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ echo ""
 echo "Generating secret key..."
 # This is to escape the secret key to be used in sed below
 SECRET_KEY=$(head /dev/urandom | env LC_CTYPE=C tr -dc "a-z0-9@#%^&*(-_=+)" | head -c 50 | sed -e 's/[\/&]/\\&/g')
-sed -i -e 's/^SECRET_KEY=.*$/SECRET_KEY= '"'$SECRET_KEY'"'/' $DISPATCH_CONFIG_ENV
+sed '/^SECRET_KEY=/{h;s/=.*/='"'$SECRET_KEY'"'/};${x;/^$/{s//SECRET_KEY='"'$SECRET_KEY'"'/;H};x}' $DISPATCH_CONFIG_ENV
 echo "Secret key written to $DISPATCH_CONFIG_ENV"
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -35,7 +35,7 @@ function ensure_file_from_example {
     echo "$1 already exists, skipped creation."
   else
     echo "Creating $1..."
-    cp -n $(echo "$1" | sed 's/\.[^.]*$/.example&/') "$1"
+    cp -n $(echo "$1" | sed 's/\.[^.]*$/&.example/') "$1"
   fi
 }
 
@@ -54,16 +54,16 @@ if [ "$RAM_AVAILABLE_IN_DOCKER" -lt "$MIN_RAM" ]; then
     exit -1
 fi
 
+echo ""
+ensure_file_from_example $DISPATCH_CONFIG_ENV
+ensure_file_from_example $DISPATCH_EXTRA_REQUIREMENTS
+
 # Clean up old stuff and ensure nothing is working while we install/update
 docker-compose down --rmi local --remove-orphans
 
 echo ""
 echo "Creating volumes for persistent storage..."
 echo "Created $(docker volume create --name=dispatch-postgres)."
-
-echo ""
-ensure_file_from_example $DISPATCH_CONFIG_ENV
-ensure_file_from_example $DISPATCH_EXTRA_REQUIREMENTS
 
 echo ""
 echo "Generating secret key..."


### PR DESCRIPTION
Running install.sh when there is no .env file present causes two issues

1- The following error is observed
```
dispatch-docker git:master  ❯ ./install.sh                                                                                                                      
Checking minimum requirements...
ERROR: Couldn't find env file: /home/user/folder/dispatch-docker/.env
Cleaning up...
```
If there is no .env file present, the installer fails before reaching 'ensure_file_from_example' because 'docker-compose down --rmi local --remove-orphans' will be expecting .env file present. Therefore changing the order of 'ensure_file_from_example' so that it happens before 'docker-compose down --rmi local --remove-orphans' would fix the issue

2- The following error is observed
```
Cannot stat /.example.env: File not found
```
This happens because the cp/sed expression inside 'ensure_file_from_example' is attempting to copy the non-existent file .example.env while it should be copying .env.example