### PR TITLE
Rename requirements.example.txt to requirements.txt.example

### DIFF
--- a/requirements.example.txt
+++ b/requirements.example.txt
@@ -1,1 +1,0 @@
-# plugins here

--- a/requirements.txt.example
+++ b/requirements.txt.example
@@ -1,0 +1,1 @@
+# plugins here


### PR DESCRIPTION
The file must end with .example to be correctly recognized by the copy command in install.sh:37