### PR TITLE
fix: update psql command for loading example data

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -121,7 +121,7 @@ else
     wget https://raw.githubusercontent.com/Netflix/dispatch/master/data/dispatch-sample-data.dump
     export PGPASSWORD='dispatch'
     createdb -h localhost -p 5432 -U dispatch dispatch
-    psql -h localhost -p 5432 -U dispatch -d dispatch -v ./dispatch-sample-data.dump
+    psql -h localhost -p 5432 -U dispatch -d dispatch -f ./dispatch-sample-data.dump
     echo "Example data loaded. Navigate to /register and create a new user."
   else
     echo "Running standard database migrations..."


### PR DESCRIPTION
I'm not sure how this `-v` flag got in here, but that is incorrect usage on version `psql (PostgreSQL) 12.1`

Instead, use the `-f` flag


```
       -v assignment
       --set=assignment
       --variable=assignment
           Perform a variable assignment, like the \set meta-command. Note that you must separate name and value, if any, by an equal sign on the command line. To
           unset a variable, leave off the equal sign. To set a variable with an empty value, use the equal sign but leave off the value. These assignments are done
           during command line processing, so variables that reflect connection state will get overwritten later.
```

```
       -f filename
       --file=filename
           Read commands from the file filename, rather than standard input. This option can be repeated and combined in any order with the -c option. When either -c
           or -f is specified, psql does not read commands from standard input; instead it terminates after processing all the -c and -f options in sequence. Except
           for that, this option is largely equivalent to the meta-command \i.

           If filename is - (hyphen), then standard input is read until an EOF indication or \q meta-command. This can be used to intersperse interactive input with
           input from files. Note however that Readline is not used in this case (much as if -n had been specified).

           Using this option is subtly different from writing psql < filename. In general, both will do what you expect, but using -f enables some nice features such
           as error messages with line numbers. There is also a slight chance that using this option will reduce the start-up overhead. On the other hand, the variant
           using the shell's input redirection is (in theory) guaranteed to yield exactly the same output you would have received had you entered everything by hand.
```