### PR TITLE
install: use curl instead of wget

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -118,7 +118,7 @@ if [ $CI ]; then
 else
   read -p "Do you want to load example data (y/N)?" CONT
   if [ "$CONT" = "y" ]; then
-    wget https://raw.githubusercontent.com/Netflix/dispatch/master/data/dispatch-sample-data.dump
+    curl -O https://raw.githubusercontent.com/Netflix/dispatch/master/data/dispatch-sample-data.dump
     export PGPASSWORD='dispatch'
     createdb -h localhost -p 5432 -U dispatch dispatch
     psql -h localhost -p 5432 -U dispatch -d dispatch -v ./dispatch-sample-data.dump


### PR DESCRIPTION
The install script crapped out since I didn't have `wget` installed. 
`curl` is more popular and is shipped by default on more systems

This also makes the script more idempotent, as it's intended to be, since the current command doesn't overwrite the existing data dump when fetched (it creates `dispatch-sample-data.dump1`, `dispatch-sample-data.dump2`, ...)

This `curl` command does overwrite the file if it exists.