### PR TITLE
Remove dependency to local postgres client tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Official bootstrap for running your own `Dispatch` with [Docker](https://www.doc
 
 - Docker 17.05.0+
 - Compose 1.19.0+
-- [PostgreSQL Client Applications](https://www.postgresql.org/docs/current/reference-client.html). They're included with PostgreSQL, which can be downloaded from [here](https://www.postgresql.org/download/).
 
 ## Minimum Hardware Requirements:
 

--- a/install.sh
+++ b/install.sh
@@ -120,7 +120,6 @@ else
   if [ "$CONT" = "y" ]; then
     echo "Downloading example data from Dispatch repository..."
     curl -O https://raw.githubusercontent.com/Netflix/dispatch/latest/data/dispatch-sample-data.dump
-    export PGPASSWORD='dispatch'
     echo "Dropping database dispatch if it already exists..."
     docker-compose run -e PGPASSWORD='dispatch' --rm postgres dropdb -h postgres -p 5432 -U dispatch dispatch --if-exists
     echo "Creating dispatch database..."

--- a/install.sh
+++ b/install.sh
@@ -9,8 +9,8 @@ DISPATCH_CONFIG_ENV='./.env'
 DISPATCH_EXTRA_REQUIREMENTS='./requirements.txt'
 
 DISPATCH_DB_PASSWORD='dispatch'
-DISPATCH_DB_SAMPLE_DATA_URL='https://raw.githubusercontent.com/Netflix/dispatch/latest/data/dispatch-sample-data.dump'
 DISPATCH_DB_SAMPLE_DATA_FILE='dispatch-sample-data.dump'
+DISPATCH_DB_SAMPLE_DATA_URL="https://raw.githubusercontent.com/Netflix/dispatch/latest/data/${DISPATCH_DB_SAMPLE_DATA_FILE}"
 
 DID_CLEAN_UP=0
 # the cleanup function will be the exit point

--- a/install.sh
+++ b/install.sh
@@ -122,11 +122,11 @@ else
     curl -O https://raw.githubusercontent.com/Netflix/dispatch/latest/data/dispatch-sample-data.dump
     export PGPASSWORD='dispatch'
     echo "Dropping database dispatch if it already exists..."
-    dropdb -h localhost -p 5432 -U dispatch dispatch --if-exists
+    docker-compose run -e PGPASSWORD='dispatch' --rm postgres dropdb -h postgres -p 5432 -U dispatch dispatch --if-exists
     echo "Creating dispatch database..."
-    createdb -h localhost -p 5432 -U dispatch dispatch
+    docker-compose run -e PGPASSWORD='dispatch' --rm postgres createdb -h postgres -p 5432 -U dispatch dispatch
     echo "Loading example data to the database..."
-    psql -h localhost -p 5432 -U dispatch -d dispatch -f ./dispatch-sample-data.dump
+    docker-compose run -e PGPASSWORD='dispatch' -v "$(pwd)/dispatch-sample-data.dump:/dispatch-sample-data.dump" --rm postgres psql -h postgres -p 5432 -U dispatch -d dispatch -f /dispatch-sample-data.dump
     echo "Example data loaded. Navigate to /register and create a new user."
   fi
   echo "Running standard database migrations..."


### PR DESCRIPTION
I run into the same issue as #92 since I did not have postgres client tools installed. This merge request moves the postgres calls (to initialize the test data) to be run within the docker container. This way nothing but docker needs to be installed to run dispatch and to initialize test data.