### PR TITLE
Allow build time variables VUE_APP_*

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,7 @@
 set -e
 
 COMPOSE_DOCKER_CLI_BUILD=0
+COMPOSE_BUILD_ARGS="$(grep -E '^(VUE_APP)' ${DISPATCH_CONFIG_ENV} | while read var ; do printf %b "--build-arg ${var} "; done)"
 
 MIN_DOCKER_VERSION='17.05.0'
 MIN_COMPOSE_VERSION='1.19.0'
@@ -98,7 +99,7 @@ echo ""
 echo "Pulling, building, and tagging Docker images..."
 echo ""
 docker-compose pull postgres
-docker-compose build --force-rm
+docker-compose build ${COMPOSE_BUILD_ARGS} --force-rm
 echo ""
 echo "Docker images pulled and built."
 


### PR DESCRIPTION
There is an issue when using latest release all `VUE_APP_*` variables coming from `.env` ignored.
To make this work we checkout `dispatch`, set context to `../dispatch` and add these variables to `../dispatch/src/dispatch/static/dispatch/.env`

To reproduce:
1. create [.env](https://github.com/Netflix/dispatch-docker/blob/master/.env.example) file
2. add `VUE_APP_DISPATCH_AUTHENTICATION_PROVIDER_SLUG=dispatch-auth-provider-pkce`
3. run `./install.sh`
4. debug in browser show `undefined` for `VUE_APP_DISPATCH_AUTHENTICATION_PROVIDER_SLUG` value and dispatch falls back to basic auth 🤷🏻‍♂️ 

This is because docker uses env file only during run process, not build process.

Additional change is required on `Dockerfile` side: https://github.com/Netflix/dispatch/pull/1533